### PR TITLE
Validation job == s"$repo-${pull.base.ref}-$jobSuffix"

### DIFF
--- a/core/src/main/scala/Core.scala
+++ b/core/src/main/scala/Core.scala
@@ -29,6 +29,8 @@ trait Core extends Util {
   // marker for messages understood by PullRequestActor
   trait PRMessage
 
+  type PullRequest
+
   // see also scala-jenkins-infra
   final val PARAM_REPO_USER = "repo_user"
   final val PARAM_REPO_NAME = "repo_name"
@@ -37,8 +39,8 @@ trait Core extends Util {
   final val PARAM_LAST      = "_scabot_last" // TODO: temporary until we run real integration on the actual merge commit
 
   trait JobContextLense {
-    def contextForJob(job: String): Option[String]
-    def jobForContext(context: String): Option[String]
+    def contextForJob(job: String, pull: PullRequest): Option[String]
+    def jobForContext(context: String, pull: PullRequest): Option[String]
   }
 }
 

--- a/github/src/main/scala/scabot/github/GithubApi.scala
+++ b/github/src/main/scala/scabot/github/GithubApi.scala
@@ -66,8 +66,8 @@ trait GithubApiTypes { self: core.Core with core.Configuration =>
 
   // TODO: factory method that caps state to 140 chars
   case class CommitStatus(state: String, context: Option[String] = None, description: Option[String] = None, target_url: Option[String] = None) extends HasState with HasContext {
-    def forJob(job: String)(implicit lense: JobContextLense): Boolean = lense.contextForJob(job) == context
-    def jobName(implicit lense: JobContextLense): Option[String] = context.flatMap(lense.jobForContext)
+    def forJob(job: String, pull: PullRequest)(implicit lense: JobContextLense): Boolean = lense.contextForJob(job, pull) == context
+    def jobName(pull: PullRequest)(implicit lense: JobContextLense): Option[String] = context.flatMap(lense.jobForContext(_, pull))
   }
 
   case class IssueComment(body: String, user: Option[User] = None, created_at: Date = None, updated_at: Date = None, id: Option[Long] = None) extends PRMessage


### PR DESCRIPTION
Make job dependent on repo, PR's target branch and jobSuffix.

Scabot's conf will need to be updated.
Replace `job: "scala-2.11.x-validate-main"` with `jobSuffix: "validate-main"`,
and add `branches: ["2.11.x", "2.12.x"]` to the github section.

Two birds with one stone: split 2.11/2.12 CI validation jobs,
share our infrastructure with the dotty team.