### PR TITLE
CLA check is 404 when not signed

### DIFF
--- a/typesafe/src/main/scala/scabot/typesafe/TypesafeApi.scala
+++ b/typesafe/src/main/scala/scabot/typesafe/TypesafeApi.scala
@@ -23,6 +23,6 @@ trait TypesafeApiActions extends TypesafeJsonProtocol { self: core.Core with cor
     private implicit def connection = setupConnection("www.typesafe.com")
     import spray.json._
 
-    def checkCla(user: String) = p[CLARecord](Get(Uri("/contribute/cla/scala/check" / user)))
+    def checkCla(user: String) = pWithStatus[CLARecord](Get(Uri("/contribute/cla/scala/check" / user)))
   }
 }


### PR DESCRIPTION
This caused the CLA status to remain at pending when the user had not signed the CLA, since the unmarshal failed for non-successful status codes.