### PR TITLE
replace checkin jobs with scabot logic

### DIFF
--- a/amazon/src/main/scala/DynamoDb.scala
+++ b/amazon/src/main/scala/DynamoDb.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 /**
  * Created by adriaan on 1/23/15.
  */
-trait DynamoDb { self: core.Core =>
+trait DynamoDb extends core.Core {
   class DynoDbClient {
     private lazy val dynamoDBClient = {
       val ipcp   = new InstanceProfileCredentialsProvider()

--- a/core/src/main/scala/Configuration.scala
+++ b/core/src/main/scala/Configuration.scala
@@ -2,7 +2,7 @@ package scabot.core
 
 import com.typesafe.config.{Config => TConfig, _}
 
-trait Configuration { self: Core =>
+trait Configuration extends Core {
 
   def configFile: java.io.File
 

--- a/core/src/main/scala/Core.scala
+++ b/core/src/main/scala/Core.scala
@@ -12,7 +12,7 @@ import spray.httpx.unmarshalling._
 
 import scala.concurrent.{Promise, Future, ExecutionContext}
 
-trait Core extends Util {
+trait Core {
 
   // We need an ActorSystem not only for the actors that make up
   // the server, but also in order to use akka.io.IO's HTTP support,
@@ -46,7 +46,7 @@ trait Core extends Util {
   }
 }
 
-trait Util { self: Core =>
+trait Util {
   def findFirstSequentially[T](futures: Stream[Future[T]])(p: T => Boolean): Future[T] = {
     val resultPromise = Promise[T]
     def loop(futures: Stream[Future[T]]): Unit =
@@ -68,7 +68,7 @@ trait Util { self: Core =>
 }
 
 
-trait HttpClient { self: Core =>
+trait HttpClient extends Core {
   import spray.can.Http.HostConnectorSetup
   import spray.client.pipelining._
   import spray.http.{HttpCredentials, HttpRequest}
@@ -112,7 +112,7 @@ trait HttpClient { self: Core =>
 }
 
 // for experimenting with the actors logic
-trait NOOPHTTPClient extends HttpClient { self: Core =>
+trait NOOPHTTPClient extends HttpClient {
   override def setupConnection(host: String, credentials: Option[HttpCredentials] = None): Future[SendReceive] =
     Future.successful{ x => logRequest(system.log, akka.event.Logging.InfoLevel).apply(x); Future.successful(HttpResponse()) }
 }

--- a/core/src/main/scala/Core.scala
+++ b/core/src/main/scala/Core.scala
@@ -12,6 +12,8 @@ import spray.httpx.unmarshalling._
 
 import scala.concurrent.{Promise, Future, ExecutionContext}
 
+class BaseRef(val name: String) extends AnyVal
+
 trait Core {
 
   // We need an ActorSystem not only for the actors that make up
@@ -41,12 +43,12 @@ trait Core {
   final val PARAM_LAST      = "_scabot_last" // TODO: temporary until we run real integration on the actual merge commit
 
   trait JobContextLense {
-    def contextForJob(job: String, pull: PullRequest): Option[String]
-    def jobForContext(context: String, pull: PullRequest): Option[String]
+    def contextForJob(job: String, baseRef: BaseRef): Option[String]
+    def jobForContext(context: String, baseRef: BaseRef): Option[String]
   }
 }
 
-trait Util {
+trait Util extends Core {
   def findFirstSequentially[T](futures: Stream[Future[T]])(p: T => Boolean): Future[T] = {
     val resultPromise = Promise[T]
     def loop(futures: Stream[Future[T]]): Unit =

--- a/github/src/main/scala/scabot/github/GithubApi.scala
+++ b/github/src/main/scala/scabot/github/GithubApi.scala
@@ -61,7 +61,7 @@ trait GithubApiTypes extends core.Core {
   case class Issue(number: Int, state: String, title: String, body: Option[String], user: User, labels: List[Label],
                    assignee: Option[User], milestone: Option[Milestone], created_at: Date, updated_at: Date, closed_at: Date)
 
-  case class CommitInfo(message: String, timestamp: Date, author: Author, committer: Author)
+  case class CommitInfo(id: String, message: String, timestamp: Date, author: Author, committer: Author)
     // added: Option[List[String]], removed: Option[List[String]], modified: Option[List[String]]
   case class Commit(sha: String, commit: CommitInfo, url: Option[String] = None)
 
@@ -96,8 +96,8 @@ trait GithubApiTypes extends core.Core {
                                 // diff_hunk, original_position, original_commit_id
 
   case class PullRequestEvent(action: String, number: Int, pull_request: PullRequest) extends ProjectMessage with PRMessage
-  case class PushEvent(ref: String, before: String, after: String, created: Boolean, deleted: Boolean, forced: Boolean,
-                       base_ref: Option[String], commits: List[CommitInfo], head_commit: CommitInfo, repository: Repository, pusher: Author)
+  case class PushEvent(ref_name: String, distinct_commits: List[CommitInfo], repository: Repository) extends ProjectMessage
+//                        ref: String, before: String, after: String, created: Boolean, deleted: Boolean, forced: Boolean,  base_ref: Option[String], commits: List[CommitInfo], head_commit: CommitInfo, repository: Repository, pusher: Author)
   case class PullRequestReviewCommentEvent(action: String, pull_request: PullRequest, comment: PullRequestComment, repository: Repository)  extends ProjectMessage
   case class IssueCommentEvent(action: String, issue: Issue, comment: IssueComment, repository: Repository) extends ProjectMessage
 
@@ -125,7 +125,7 @@ trait GithubJsonProtocol extends GithubApiTypes with DefaultJsonProtocol with co
   implicit lazy val _fmtMilestone        : RJF[Milestone]                     = jsonFormat9(Milestone.apply)
   implicit lazy val _fmtIssue            : RJF[Issue]                         = jsonFormat11(Issue)
 
-  implicit lazy val _fmtCommitInfo       : RJF[CommitInfo]                    = jsonFormat4(CommitInfo)
+  implicit lazy val _fmtCommitInfo       : RJF[CommitInfo]                    = jsonFormat5(CommitInfo)
   implicit lazy val _fmtCommit           : RJF[Commit]                        = jsonFormat3(Commit)
   implicit lazy val _fmtCommitStatus     : RJF[CommitStatus]                  = jsonFormat4(CommitStatus.apply)
   implicit lazy val _fmtCombiCommitStatus: RJF[CombiCommitStatus]             = jsonFormat(CombiCommitStatus, "state", "sha", "statuses", "total_count") // need to specify field names because we added methods to the case class..
@@ -134,7 +134,7 @@ trait GithubJsonProtocol extends GithubApiTypes with DefaultJsonProtocol with co
   implicit lazy val _fmtPullRequestComment: RJF[PullRequestComment]           = jsonFormat8(PullRequestComment)
 
   implicit lazy val _fmtPullRequestEvent : RJF[PullRequestEvent]              = jsonFormat3(PullRequestEvent)
-  implicit lazy val _fmtPushEvent        : RJF[PushEvent]                     = jsonFormat11(PushEvent)
+  implicit lazy val _fmtPushEvent        : RJF[PushEvent]                     = jsonFormat3(PushEvent)
   implicit lazy val _fmtPRCommentEvent   : RJF[PullRequestReviewCommentEvent] = jsonFormat4(PullRequestReviewCommentEvent)
   implicit lazy val _fmtIssueCommentEvent: RJF[IssueCommentEvent]             = jsonFormat4(IssueCommentEvent)
 

--- a/github/src/main/scala/scabot/github/GithubApi.scala
+++ b/github/src/main/scala/scabot/github/GithubApi.scala
@@ -9,6 +9,8 @@
 package scabot
 package github
 
+import scabot.core.BaseRef
+
 trait GithubApi extends GithubApiTypes with GithubJsonProtocol with GithubApiActions
 
 // definitions in topo-order, no cycles in dependencies
@@ -84,8 +86,8 @@ trait GithubApiTypes extends core.Core {
 
   // TODO: factory method that caps state to 140 chars
   case class CommitStatus(state: String, context: Option[String] = None, description: Option[String] = None, target_url: Option[String] = None) extends HasState with HasContext {
-    def forJob(job: String, pull: PullRequest)(implicit lense: JobContextLense): Boolean = lense.contextForJob(job, pull) == context
-    def jobName(pull: PullRequest)(implicit lense: JobContextLense): Option[String] = context.flatMap(lense.jobForContext(_, pull))
+    def forJob(job: String, baseRef: BaseRef)(implicit lense: JobContextLense): Boolean = lense.contextForJob(job, baseRef) == context
+    def jobName(baseRef: BaseRef)(implicit lense: JobContextLense): Option[String] = context.flatMap(lense.jobForContext(_, baseRef))
   }
 
   case class IssueComment(body: String, user: Option[User] = None, created_at: Date = None, updated_at: Date = None, id: Option[Long] = None) extends PRMessage

--- a/github/src/main/scala/scabot/github/GithubApi.scala
+++ b/github/src/main/scala/scabot/github/GithubApi.scala
@@ -9,10 +9,10 @@
 package scabot
 package github
 
-trait GithubApi extends GithubApiTypes with GithubJsonProtocol with GithubApiActions { self: core.Core with core.HttpClient with core.Configuration => }
+trait GithubApi extends GithubApiTypes with GithubJsonProtocol with GithubApiActions
 
 // definitions in topo-order, no cycles in dependencies
-trait GithubApiTypes { self: core.Core =>
+trait GithubApiTypes extends core.Core {
   // spray json seems to disregard the expected type and won't unmarshall a json number as a String (sometimes github uses longs, sometimes string reps)
   type Date = Option[Either[String, Long]]
 
@@ -109,7 +109,7 @@ import spray.json.{RootJsonFormat, DefaultJsonProtocol}
 
 // TODO: can we make this more debuggable?
 // TODO: test against https://github.com/github/developer.github.com/tree/master/lib/webhooks
-trait GithubJsonProtocol extends GithubApiTypes with DefaultJsonProtocol { self: core.Core with core.Configuration =>
+trait GithubJsonProtocol extends GithubApiTypes with DefaultJsonProtocol with core.Configuration {
   private type RJF[x] = RootJsonFormat[x]
   implicit lazy val _fmtUser             : RJF[User]                          = jsonFormat1(User)
   implicit lazy val _fmtAuthor           : RJF[Author]                        = jsonFormat2(Author)
@@ -140,7 +140,7 @@ trait GithubJsonProtocol extends GithubApiTypes with DefaultJsonProtocol { self:
   // implicit lazy val _fmtAuthApp          : RJF[AuthApp]                       = jsonFormat2(AuthApp)
 }
 
-trait GithubApiActions extends GithubJsonProtocol { self: core.Core with core.Configuration with core.HttpClient =>
+trait GithubApiActions extends GithubJsonProtocol with core.HttpClient {
   class GithubConnection(config: Config.Github) {
     import spray.http.{GenericHttpCredentials, Uri}
     import spray.httpx.SprayJsonSupport._

--- a/github/src/main/scala/scabot/github/GithubService.scala
+++ b/github/src/main/scala/scabot/github/GithubService.scala
@@ -6,7 +6,7 @@ import akka.event.Logging
 import scala.util.{Success, Failure}
 
 
-trait GithubService extends core.Core with GithubApi { self: core.HttpClient with core.Configuration =>
+trait GithubService extends GithubApi {
   import spray.httpx.SprayJsonSupport._
 
   private lazy val UserRepo = """([^/]+)/(.+)""".r

--- a/github/src/main/scala/scabot/github/GithubService.scala
+++ b/github/src/main/scala/scabot/github/GithubService.scala
@@ -23,11 +23,10 @@ trait GithubService extends GithubApi {
       notifyProject(ev, ev.pull_request.base.repo)
   }
 
-//  def pushEvent(ev: PushEvent): String = ev match {
-//    case PushEvent(ref, before, after, created, deleted, forced, base_ref, commits, head_commit, repository, pusher) =>
-//      println(ev)
-//      ev.toString
-//  }
+  def pushEvent(ev: PushEvent): String = ev match {
+    case PushEvent(ref, commits, repository) =>
+      notifyProject(ev, repository)
+  }
 
   def issueCommentEvent(ev: IssueCommentEvent): String = ev match {
     case IssueCommentEvent(action, issue, comment, repository) =>

--- a/gui/app/controllers/Scabot.scala
+++ b/gui/app/controllers/Scabot.scala
@@ -45,6 +45,7 @@ class Scabot @Inject() (val system: ActorSystem) extends Controller with GithubS
       case "issue_comment"               => handleWith(issueCommentEvent)
       case "pull_request_review_comment" => handleWith(pullRequestReviewCommentEvent)
       case "pull_request"                => handleWith(pullRequestEvent)
+      case "push"                        => handleWith(pushEvent)
       // case "status"                   => TODO: use this to propagate combined contexts -- problem: the (payload)[https://developer.github.com/v3/activity/events/types/#statusevent] does not specify the PR
     } match {
       case Some(Success(message)) => Ok(message)

--- a/jenkins/src/main/scala/scabot/jenkins/JenkinsAPI.scala
+++ b/jenkins/src/main/scala/scabot/jenkins/JenkinsAPI.scala
@@ -6,9 +6,9 @@ import spray.http.BasicHttpCredentials
 import scala.concurrent.Future
 import scala.util.Try
 
-trait JenkinsApi extends JenkinsApiTypes with JenkinsJsonProtocol with JenkinsApiActions { self: core.Core with core.Configuration with core.HttpClient => }
+trait JenkinsApi extends JenkinsApiTypes with JenkinsJsonProtocol with JenkinsApiActions
 
-trait JenkinsApiTypes { self: core.Core with core.Configuration =>
+trait JenkinsApiTypes extends core.Configuration {
   object Job {
     // avoid humongeous replies that would require more spray sophistication (chunking etc)
     val XPath = "?tree=name,description,nextBuildNumber,builds[number,url],queueItem[*],lastBuild[number,url],firstBuild[number,url]"
@@ -121,7 +121,7 @@ trait JenkinsApiTypes { self: core.Core with core.Configuration =>
 import spray.json.{RootJsonFormat, DefaultJsonProtocol}
 
 // TODO: can we make this more debuggable?
-trait JenkinsJsonProtocol extends JenkinsApiTypes with DefaultJsonProtocol { self: core.Core with core.Configuration =>
+trait JenkinsJsonProtocol extends JenkinsApiTypes with DefaultJsonProtocol {
   private type RJF[x] = RootJsonFormat[x]
   implicit lazy val _fmtJob         : RJF[Job        ] = jsonFormat7(Job.apply)
   implicit lazy val _fmtBuild       : RJF[Build      ] = jsonFormat2(Build)
@@ -136,7 +136,7 @@ trait JenkinsJsonProtocol extends JenkinsApiTypes with DefaultJsonProtocol { sel
   implicit lazy val _fmtScmState    : RJF[ScmParams  ] = jsonFormat3(ScmParams)
 }
 
-trait JenkinsApiActions extends JenkinsJsonProtocol { self: core.Core with core.Configuration with core.HttpClient =>
+trait JenkinsApiActions extends JenkinsJsonProtocol with core.HttpClient {
   class JenkinsConnection(config: Config.Jenkins) {
     import spray.http.{GenericHttpCredentials, Uri}
     import spray.httpx.SprayJsonSupport._

--- a/jenkins/src/main/scala/scabot/jenkins/JenkinsService.scala
+++ b/jenkins/src/main/scala/scabot/jenkins/JenkinsService.scala
@@ -3,7 +3,7 @@ package jenkins
 
 import akka.event.Logging
 
-trait JenkinsService extends core.Core with JenkinsApi { self: core.HttpClient with core.Configuration =>
+trait JenkinsService extends JenkinsApi {
 
   def jenkinsEvent(jobState: JobState): String = jobState match {
     case JobState(name, _, BuildState(number, phase, parameters, scm, result, full_url, log)) =>

--- a/server/src/main/scala/Actors.scala
+++ b/server/src/main/scala/Actors.scala
@@ -4,9 +4,11 @@ package server
 import java.util.NoSuchElementException
 
 import akka.actor._
+import akka.event.LoggingAdapter
 import com.amazonaws.services.dynamodbv2.document.{Item, PrimaryKey}
 import com.amazonaws.services.dynamodbv2.model.KeyType
 import scabot.amazon.DynamoDb
+import scabot.core.BaseRef
 
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -92,28 +94,156 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
     }
   }
 
+  trait Building {
+    def config: Config
+    def githubApi: GithubConnection
+    def jenkinsApi: JenkinsConnection
+    def log: LoggingAdapter
+
+    def milestoneForBranch(branch: String): Future[Milestone] = for {
+      mss <- githubApi.repoMilestones()
+      ms <- Future {
+        val msOpt = mss.find(_.mergeBranch == Some(branch))
+        log.debug(s"Looking for milestone for $branch: $msOpt")
+        msOpt.get
+      }
+    } yield ms
+
+    def fetchCommitStatus(sha: String) = {
+      val fetcher = githubApi.commitStatus(sha)
+      fetcher.onFailure { case e => log.warning(s"Couldn't get status for ${sha}: $e")}
+      fetcher
+    }
+
+    implicit object jcl extends JobContextLense {
+      // e.g., scala-2.11.x- for PR targeting 2.11.x of s"$user/scala" (for any user)
+      def prefix(baseRef: BaseRef) = s"${config.github.repo}-${baseRef.name}-"
+
+      // TODO: as we add more analyses to PR validation, update this predicate to single out jenkins jobs
+      // NOTE: config.jenkins.job spawns other jobs, which we don't know about here, but still want to retry on /rebuild
+      def contextForJob(job: String, baseRef: BaseRef): Option[String] =
+        Some(job.replace(prefix(baseRef), "")) // TODO: should only replace *prefix*, not just anywhere in string
+
+      def jobForContext(context: String, baseRef: BaseRef): Option[String] =
+        if (CommitStatusConstants.jenkinsContext(context)) Some(prefix(baseRef) + context)
+        else None
+    }
+
+    def mainValidationJob(baseRef: BaseRef) = jcl.prefix(baseRef) + config.jenkins.jobSuffix
+
+    // TODO: is this necessary? just to be sure, as it looks like github refuses non-https links
+    def urlForBuild(bs: BuildStatus) = Some(bs.url.map(_.replace("http://", "https://")).getOrElse(""))
+
+    def stateForBuild(bs: BuildStatus) =
+      if (bs.building || bs.queued) CommitStatusConstants.PENDING
+      else if (bs.success) CommitStatusConstants.SUCCESS
+      else CommitStatusConstants.FAILURE
+
+    def contextForJob(jobName: String, baseRef: BaseRef): Option[String] = implicitly[JobContextLense].contextForJob(jobName, baseRef)
+
+    def commitStatus(jobName: String, bs: BuildStatus, baseRef: BaseRef): CommitStatus = {
+      val advice = if (bs.failed) " Say /rebuild on PR to retry *spurious* failure." else ""
+      commitStatusForContext(contextForJob(jobName, baseRef), bs, advice)
+    }
+
+    def commitStatusForContext(context: Option[String], bs: BuildStatus, advice: String): CommitStatus = {
+      CommitStatus(stateForBuild(bs), context,
+        description = Some((bs.toString + advice) take 140),
+        target_url = urlForBuild(bs))
+    }
+
+    def combiStatus(state: String, msg: String): CommitStatus =
+      CommitStatus(state, Some(CommitStatusConstants.COMBINED), description = Some(msg.take(140)))
+
+    def claStatus(signed: Option[Boolean], user: String, claKind: String, checkUrl: String, signUrl: String): CommitStatus = {
+      val (state, msg, url) = signed match {
+        case None        => (CommitStatusConstants.PENDING, s"Checking whether @$user signed the $claKind CLA.", checkUrl)
+        case Some(true)  => (CommitStatusConstants.SUCCESS, s"@$user signed the $claKind CLA. Thanks!", checkUrl)
+        case Some(false) => (CommitStatusConstants.FAILURE, s"@$user, please sign the $claKind CLA by clicking on 'Details' -->", signUrl)
+      }
+      CommitStatus(state, Some(CommitStatusConstants.CLA), description = Some(msg.take(140)), target_url = Some(url))
+    }
+
+
+    def repoParams: Map[String, String] = Map(PARAM_REPO_USER -> config.github.user, PARAM_REPO_NAME -> config.github.repo)
+
+    def commitParams(sha: String, lastCommit: Boolean): Map[String, String] = {
+      // TODO: temporary until we run real integration on the actual merge commit
+      (if (lastCommit) Map(PARAM_LAST -> "1") else Map.empty) ++ Map (PARAM_REPO_REF  -> sha )
+    }
+
+    // result is a subset of (config.jenkins.job and the contexts found in combiCommitStatus.statuses that are jenkins jobs)
+    // if not rebuilding or gathering all jobs, this subset is either empty or the main job (if no statuses were found for it)
+    // unless gatherAllJobs, the result only includes jobs whose most recent status was a failure
+    def jobsTodo(baseRef: BaseRef, combiCommitStatus: CombiCommitStatus, rebuild: Boolean): List[String] = {
+      // TODO: filter out aborted stati?
+      // TODO: for pending jobs, check that they are indeed pending!
+      def considerStati(stati: List[CommitStatus]): Boolean =
+        if (rebuild) stati.headOption.forall(_.failure) else stati.isEmpty
+
+      val mainJobForPull = mainValidationJob(baseRef)
+      val shouldConsider = Map(mainJobForPull -> true) ++: combiCommitStatus.statuses.groupBy(_.jobName(baseRef)).collect {
+        case (Some(job), stati) => (job, considerStati(stati))
+      }
+
+      log.debug(s"shouldConsider for ${combiCommitStatus.sha.take(6)} (rebuild=$rebuild, consider main job: ${shouldConsider.get(mainJobForPull)}): $shouldConsider")
+
+      val allToConsider = shouldConsider.collect{case (job, true) => job}
+
+      // We've built this before and we were asked to rebuild. For all jobs that have ended in failure, launch a build.
+      // TODO: once we support overriding main job with results of its downstream jobs,
+      //       on rebuild, we should yield only the downstream jobs, overriding the main job once they finish
+      // lazy val nonMainToBuild = allToConsider.toSet -  mainValidationJob
+
+      val jobs =
+      //        if (rebuild && nonMainToBuild.nonEmpty) nonMainToBuild.toList
+        if (shouldConsider(mainJobForPull)) List(mainJobForPull)
+        else Nil
+
+      val jobMsg =
+        if (jobs.isEmpty) "No need to build"
+        else s"Found jobs ${jobs.mkString(", ")} TODO"
+
+      log.debug(s"$jobMsg for ${combiCommitStatus.sha.take(6)} (rebuild=$rebuild), based on ${combiCommitStatus.total_count} statuses:\n${combiCommitStatus.statuses.groupBy(_.jobName(baseRef))}")
+
+      jobs
+    }
+
+
+    def launchBuild(params: Map[String, String], baseRef: BaseRef, sha: String, job: String): Future[String] = {
+      val status = commitStatus(job, new QueuedBuildStatus(params, None), baseRef)
+
+      val launcher = for {
+        posting  <- githubApi.postStatus(sha, status)
+        buildRes <- jenkinsApi.buildJob(job, params)
+        _        <- Future.successful(log.info(s"Launched $job for $sha: $buildRes"))
+      } yield buildRes
+
+      launcher onFailure { case e => log.warning(s"FAILED launchBuild($job, $baseRef, $sha, $params): $e") }
+      launcher
+    }
+
+  }
+
   // for migration
   class NoopPullRequestActor extends Actor with ActorLogging {
     override def receive: Actor.Receive = { case _ => log.warning("NOOP ACTOR SAYS HELLO") }
   }
 
-  class PullRequestActor(pr: Int, config: Config) extends Actor with ActorLogging {
+  class PullRequestActor(pr: Int, val config: Config) extends Actor with ActorLogging with Building {
     lazy val githubApi   = new GithubConnection(config.github)
     lazy val jenkinsApi  = new JenkinsConnection(config.jenkins)
     lazy val typesafeApi = new TypesafeConnection()
 
-    // currently only used for pull.base.ref, so we only create the future once (this can never change)
-    // TODO: do a .map(pull => pull.base.ref) and refactor to clarify
-    private lazy val pullCached    = githubApi.pullRequest(pr)
+    def baseRef(pull: PullRequest): BaseRef = new BaseRef(pull.base.ref)
+
+    private def pull = githubApi.pullRequest(pr)
+    private lazy val baseRefCached = pull.map(baseRef(_))
     private def pullRequestCommits = githubApi.pullRequestCommits(pr)
     private def lastSha            = pullRequestCommits map (_.last.sha)
     private def issueComments      = githubApi.issueComments(pr)
 
-    private def fetchCommitStatus(sha: String) = {
-      val fetcher = githubApi.commitStatus(sha)
-      fetcher.onFailure { case e => log.warning(s"Couldn't get status for ${sha}: $e")}
-      fetcher
-    }
+    def jobParams(sha: String, lastCommit: Boolean) = repoParams ++ Map(PARAM_PR -> pr.toString) ++ commitParams(sha, lastCommit)
 
     private var lastSynchronized: Date = None
 
@@ -166,111 +296,10 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
       propagateEarlierStati(pull)
       // don't exec commands when synching, or we'll keep executing the /sync that triggered this handlePR execution
       if (!synchOnly) execCommands(pull)
-      buildCommitsIfNeeded(pull, synchOnly = synchOnly)
+      buildCommitsIfNeeded(baseRef(pull), synchOnly = synchOnly, lastOnly = lastOnly(pull.title))
     }
 
 
-    object BuildHelp {
-      implicit object jcl extends JobContextLense {
-        // e.g., scala-2.11.x- for PR targeting 2.11.x of s"$user/scala" (for any user)
-        def prefix(pull: PullRequest) = s"${config.github.repo}-${pull.base.ref}-"
-
-        // TODO: as we add more analyses to PR validation, update this predicate to single out jenkins jobs
-        // NOTE: config.jenkins.job spawns other jobs, which we don't know about here, but still want to retry on /rebuild
-        def contextForJob(job: String, pull: PullRequest): Option[String] =
-          Some(job.replace(prefix(pull), "")) // TODO: should only replace *prefix*, not just anywhere in string
-
-        def jobForContext(context: String, pull: PullRequest): Option[String] =
-          if (CommitStatusConstants.jenkinsContext(context)) Some(prefix(pull) + context)
-          else None
-      }
-
-      // TODO: depends on PR's target (currently hardcoded to 2.11.x)
-      def mainValidationJob(pull: PullRequest) = jcl.prefix(pull) + config.jenkins.jobSuffix
-
-      // TODO: is this necessary? just to be sure, as it looks like github refuses non-https links
-      def urlForBuild(bs: BuildStatus) = Some(bs.url.map(_.replace("http://", "https://")).getOrElse(""))
-
-      def stateForBuild(bs: BuildStatus) =
-        if (bs.building || bs.queued) CommitStatusConstants.PENDING
-        else if (bs.success) CommitStatusConstants.SUCCESS
-        else CommitStatusConstants.FAILURE
-
-      def contextForJob(jobName: String, pull: PullRequest): Option[String] = implicitly[JobContextLense].contextForJob(jobName, pull)
-
-      def commitStatus(jobName: String, bs: BuildStatus, pull: PullRequest): CommitStatus = {
-        val advice = if (bs.failed) " Say /rebuild on PR to retry *spurious* failure." else ""
-        commitStatusForContext(contextForJob(jobName, pull), bs, advice)
-      }
-
-      def commitStatusForContext(context: Option[String], bs: BuildStatus, advice: String): CommitStatus = {
-        CommitStatus(stateForBuild(bs), context,
-          description = Some((bs.toString + advice) take 140),
-          target_url = urlForBuild(bs))
-      }
-
-      def combiStatus(state: String, msg: String): CommitStatus =
-        CommitStatus(state, Some(CommitStatusConstants.COMBINED), description = Some(msg.take(140)))
-
-      def claStatus(signed: Option[Boolean], user: String, claKind: String, checkUrl: String, signUrl: String): CommitStatus = {
-        val (state, msg, url) = signed match {
-          case None        => (CommitStatusConstants.PENDING, s"Checking whether @$user signed the $claKind CLA.", checkUrl)
-          case Some(true)  => (CommitStatusConstants.SUCCESS, s"@$user signed the $claKind CLA. Thanks!", checkUrl)
-          case Some(false) => (CommitStatusConstants.FAILURE, s"@$user, please sign the $claKind CLA by clicking on 'Details' -->", signUrl)
-        }
-        CommitStatus(state, Some(CommitStatusConstants.CLA), description = Some(msg.take(140)), target_url = Some(url))
-      }
-
-
-      def jobParams(sha: String, lastCommit: Boolean): Map[String, String] = {
-        // TODO: temporary until we run real integration on the actual merge commit
-        val lastParam = if (lastCommit) Map(PARAM_LAST -> "1") else Map.empty
-
-        lastParam ++ Map (
-          PARAM_PR        -> pr.toString,
-          PARAM_REPO_USER -> config.github.user,
-          PARAM_REPO_NAME -> config.github.repo,
-          PARAM_REPO_REF  -> sha
-        )
-      }
-
-      // result is a subset of (config.jenkins.job and the contexts found in combiCommitStatus.statuses that are jenkins jobs)
-      // if not rebuilding or gathering all jobs, this subset is either empty or the main job (if no statuses were found for it)
-      // unless gatherAllJobs, the result only includes jobs whose most recent status was a failure
-      def jobsTodo(pull: PullRequest, combiCommitStatus: CombiCommitStatus, rebuild: Boolean): List[String] = {
-        // TODO: filter out aborted stati?
-        // TODO: for pending jobs, check that they are indeed pending!
-        def considerStati(stati: List[CommitStatus]): Boolean =
-          if (rebuild) stati.headOption.forall(_.failure) else stati.isEmpty
-
-        val mainJobForPull = mainValidationJob(pull)
-        val shouldConsider = Map(mainJobForPull -> true) ++: combiCommitStatus.statuses.groupBy(_.jobName(pull)).collect {
-          case (Some(job), stati) => (job, considerStati(stati))
-        }
-
-        log.debug(s"shouldConsider for ${combiCommitStatus.sha.take(6)} (rebuild=$rebuild, consider main job: ${shouldConsider.get(mainJobForPull)}): $shouldConsider")
-
-        val allToConsider = shouldConsider.collect{case (job, true) => job}
-
-        // We've built this before and we were asked to rebuild. For all jobs that have ended in failure, launch a build.
-        // TODO: once we support overriding main job with results of its downstream jobs,
-        //       on rebuild, we should yield only the downstream jobs, overriding the main job once they finish
-        // lazy val nonMainToBuild = allToConsider.toSet -  mainValidationJob
-
-        val jobs =
-//        if (rebuild && nonMainToBuild.nonEmpty) nonMainToBuild.toList
-          if (shouldConsider(mainJobForPull)) List(mainJobForPull)
-          else Nil
-
-        val jobMsg =
-          if (jobs.isEmpty) "No need to build"
-          else s"Found jobs ${jobs.mkString(", ")} TODO"
-
-        log.debug(s"$jobMsg for ${combiCommitStatus.sha.take(6)} (rebuild=$rebuild), based on ${combiCommitStatus.total_count} statuses:\n${combiCommitStatus.statuses.groupBy(_.jobName(pull))}")
-
-        jobs
-      }
-    }
 
     private def handleJobState(jobName: String, sha: String, bs: BuildStatus) = {
       // not called -- see if we can live with less noise
@@ -287,15 +316,15 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
           case _: NoSuchElementException => s"Avoiding double-commenting on $sha for $jobName"
         }
 
-      import BuildHelp._
       val postStatus = (for {
-        pull    <- pullCached
-        currentStatus <- githubApi.commitStatus(sha).map(_.statuses.filter(_.forJob(jobName, pull)).headOption)
-        newStatus = commitStatus(jobName, bs, pull)
+        baseRef    <- baseRefCached
+        currentStatus <- githubApi.commitStatus(sha).map(_.statuses.filter(_.forJob(jobName, baseRef)).headOption)
+        newStatus = commitStatus(jobName, bs, baseRef)
         _       <- Future.successful(log.debug(s"New status (new? ${currentStatus != Some(newStatus)}) for $sha: $newStatus old: $currentStatus"))
         if currentStatus != Some(newStatus)
         posting <- githubApi.postStatus(sha, newStatus)
         _       <- Future.successful(log.debug(s"Posted status on $sha for $jobName $bs:\n$posting"))
+        pull    <- pull
         _       <- propagateEarlierStati(pull, sha)
 //        if !(bs.queued || bs.building || bs.success)
 //        _       <- postFailureComment(pull, bs)
@@ -308,23 +337,8 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
     }
 
 
-    private def launchBuild(pull: PullRequest, sha: String, lastCommit: Boolean, job: String): Future[String] = {
-      import BuildHelp._
-
-      val launcher = for {
-        posting  <- githubApi.postStatus(sha, commitStatus(job, new QueuedBuildStatus(jobParams(sha, lastCommit), None), pull))
-        buildRes <- jenkinsApi.buildJob(job, jobParams(sha, lastCommit))
-        _        <- Future.successful(log.info(s"Launched $job for $sha: $buildRes"))
-      } yield buildRes
-
-      launcher onFailure { case e => log.warning(s"FAILED launchBuild($sha, $job): $e") }
-      launcher
-    }
-
     // synch contexts assumed to correspond to jenkins jobs with the most recent result of the corresponding build of the jenkins job specified by the context
-    private def synchBuildStatuses(pull: PullRequest, combiCommitStatus: CombiCommitStatus, lastCommit: Boolean): Future[List[String]] = {
-      import BuildHelp._
-
+    private def synchBuildStatuses(baseRef: BaseRef, combiCommitStatus: CombiCommitStatus, lastCommit: Boolean): Future[List[String]] = {
       case class GitHubReport(state: String, url: Option[String])
       def toReport(bs: BuildStatus) = GitHubReport(stateForBuild(bs), urlForBuild(bs))
 
@@ -363,11 +377,11 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
         else Some(commitStatusForContext(Some(context), bs, ""))
 
       def synchMostRecent(context: String, report: GitHubReport) = for {
-        job  <- Future { BuildHelp.jcl.jobForContext(context, pull).get }
+        job  <- Future { jcl.jobForContext(context, baseRef).get }
         bs   <- checkMostRecent(job)
       } yield
         if (toReport(bs) == report) None
-        else Some(commitStatus(job, bs, pull))
+        else Some(commitStatus(job, bs, baseRef))
 
 
       val syncher = Future.sequence(githubReports.toList.map { case (context, report) =>
@@ -399,7 +413,7 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
     private def lastOnly(pullTitle: String) = config.github.lastCommitOnly || pullTitle.contains("[ci: last-only]") // only test last commit when requested in PR's title (e.g., for large PRs)
 
     // determine jobs needed to be built based on the commit's status, synching github's view with build statuses reported by jenkins
-    private def buildCommitsIfNeeded(pull: PullRequest, forceRebuild: Boolean = false, synchOnly: Boolean = false): Future[List[List[String]]] = {
+    private def buildCommitsIfNeeded(baseRef: BaseRef, forceRebuild: Boolean = false, synchOnly: Boolean = false, lastOnly: Boolean = false): Future[List[List[String]]] = {
       for {
         commits <- pullRequestCommits
         lastSha  = commits.last.sha // safe to assume commits of a pr is nonEmpty
@@ -408,9 +422,12 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
           for {
             combiCs  <- fetchCommitStatus(commit.sha)
             buildRes <-
-              if (synchOnly) synchBuildStatuses(pull, combiCs, combiCs.sha == lastSha)
-              else if (lastOnly(pull.title) && combiCs.sha != lastSha) Future.successful(List(s"Skipped ${combiCs.sha} on request"))
-              else Future.sequence(BuildHelp.jobsTodo(pull, combiCs, rebuild = forceRebuild).map(launchBuild(pull, combiCs.sha, combiCs.sha == lastSha, _)))
+              if (synchOnly) synchBuildStatuses(baseRef, combiCs, combiCs.sha == lastSha)
+              else if (lastOnly && combiCs.sha != lastSha) Future.successful(List(s"Skipped ${combiCs.sha} on request"))
+              else {
+                val params = jobParams(combiCs.sha, combiCs.sha == lastSha)
+                Future.sequence(jobsTodo(baseRef, combiCs, rebuild = forceRebuild).map(launchBuild(params, baseRef, combiCs.sha, _)))
+              }
           } yield buildRes
         })
       } yield results
@@ -420,7 +437,6 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
     // so that all statuses are (indirectly) considered by github when coloring the merge button green/red
     private def propagateEarlierStati(pull: PullRequest, causeSha: String = ""): Future[List[CommitStatus]] = {
       import CommitStatusConstants._
-      import BuildHelp._
 
       def postLast(lastSha: String, desc: String, state: String, lastStss: List[CommitStatus]) =
         for { _ <- Future.successful(())
@@ -459,15 +475,6 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
 
 
     // MILESTONE
-    private def milestoneForBranch(branch: String): Future[Milestone] = for {
-      mss <- githubApi.repoMilestones()
-      ms <- Future {
-        val msOpt = mss.find(_.mergeBranch == Some(branch))
-        log.debug(s"Looking for milestone for $branch: $msOpt")
-        msOpt.get
-      }
-    } yield ms
-
 
     // if there's a milestone with description "Merge to ${pull.base.ref}.", set it as the PR's milestone
     private def checkMilestone(pull: PullRequest) =
@@ -517,9 +524,9 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
       }
 
       for {
-        pending   <- githubApi.postStatus(last, BuildHelp.claStatus(None, user, claKind, checkUrl, signUrl))
+        pending   <- githubApi.postStatus(last, claStatus(None, user, claKind, checkUrl, signUrl))
         claRecord <- checkCla
-        res       <- githubApi.postStatus(last, BuildHelp.claStatus(Some(claRecord.signed), user, claKind, checkUrl, signUrl))
+        res       <- githubApi.postStatus(last, claStatus(Some(claRecord.signed), user, claKind, checkUrl, signUrl))
       } yield res
     }
 
@@ -595,22 +602,23 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
       final val REBUILD_SHA = """^/rebuild (\w+)""".r.unanchored
       def rebuildSha(sha: String) = for {
         commits <- pullRequestCommits
-        pull    <- pullCached
-        lastSha = commits.last.sha // safe to assume commits of a pr is nonEmpty
-        build <- launchBuild(pull, sha, sha == lastSha, BuildHelp.mainValidationJob(pull))
+        baseRef <- baseRefCached
+        params  = jobParams(sha, sha == commits.last.sha) // safe to assume commits of a pr is nonEmpty
+        build <- launchBuild(params, baseRef, sha, mainValidationJob(baseRef))
       } yield build
 
       final val REBUILD_ALL = """^/rebuild""".r.unanchored
       def rebuildAll() =
         for {
-          pull     <- pullCached
-          buildRes <- buildCommitsIfNeeded(pull, forceRebuild = true)
+          pull     <- pull
+          baseRef <- baseRefCached
+          buildRes <- buildCommitsIfNeeded(baseRef, forceRebuild = true, lastOnly = lastOnly(pull.title))
         } yield buildRes
 
       final val SYNCH = """^/sync""".r.unanchored
       def synch() =
         for {
-          pull     <- pullCached
+          pull     <- pull
           synchRes <- handlePR("synchronize", pull, synchOnly = true)
         } yield synchRes
 

--- a/server/src/main/scala/Actors.scala
+++ b/server/src/main/scala/Actors.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 /**
  * Created by adriaan on 1/15/15.
  */
-trait Actors extends DynamoDb { self: core.Core with core.Configuration with github.GithubApi with jenkins.JenkinsApi with typesafe.TypesafeApi =>
+trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.TypesafeApi with DynamoDb with core.Util {
   def system: ActorSystem
 
   private lazy val githubActor = system.actorOf(Props(new GithubActor), "github")

--- a/server/src/main/scala/Actors.scala
+++ b/server/src/main/scala/Actors.scala
@@ -107,16 +107,16 @@ trait Actors extends github.GithubApi with jenkins.JenkinsApi with typesafe.Type
           bs      <- jenkinsApi.buildStatus(name, number)
           prParam <- Future { log.debug(s"Build status for $name #$number: $bs");  bs.parameters(PARAM_PR) }
           jobRes  = JenkinsJobResult(name, bs)
-          res     <-
+          _       <-
             Future { prParam.toInt } map { pr =>
               prActor(pr) ! jobRes
             } recover { case _: NumberFormatException =>
               for {
                 _   <- milestoneForBranch(prParam) // check prParam is a branch name we recognize
-                res <- postStatus(new BaseRef(prParam), jobRes)
-              } yield res
+                _   <- postStatus(new BaseRef(prParam), jobRes)
+              } yield ()
             }
-        } yield res
+        } yield ()
     }
 
     // determine jobs needed to be built based on the commit's status, synching github's view with build statuses reported by jenkins

--- a/typesafe/src/main/scala/scabot/typesafe/TypesafeApi.scala
+++ b/typesafe/src/main/scala/scabot/typesafe/TypesafeApi.scala
@@ -3,18 +3,18 @@ package typesafe
 
 import spray.json.{RootJsonFormat, DefaultJsonProtocol}
 
-trait TypesafeApi extends TypesafeApiTypes with DefaultJsonProtocol with TypesafeApiActions { self: core.Core with core.HttpClient with core.Configuration => }
+trait TypesafeApi extends TypesafeApiTypes with DefaultJsonProtocol with TypesafeApiActions
 
-trait TypesafeApiTypes { self: core.Core with core.Configuration =>
+trait TypesafeApiTypes {
   case class CLARecord(user: String, signed: Boolean, version: Option[String], currentVersion: String)
 }
 
-trait TypesafeJsonProtocol extends TypesafeApiTypes with DefaultJsonProtocol { self: core.Core with core.Configuration =>
+trait TypesafeJsonProtocol extends TypesafeApiTypes with DefaultJsonProtocol {
   private type RJF[x] = RootJsonFormat[x]
   implicit lazy val _fmtCLARecord: RJF[CLARecord] = jsonFormat4(CLARecord)
 }
 
-trait TypesafeApiActions extends TypesafeJsonProtocol { self: core.Core with core.Configuration with core.HttpClient =>
+trait TypesafeApiActions extends TypesafeJsonProtocol with core.HttpClient {
   class TypesafeConnection {
     import spray.http.{GenericHttpCredentials, Uri}
     import spray.httpx.SprayJsonSupport._


### PR DESCRIPTION
[Haven't tested this yet.]

Run PR validation on pushes to master-like branches, and post status to commit.

The goal is to retire the scala-checkin jobs at EPFL (the 2.12.x is failing because no java 8)